### PR TITLE
Changes exif to a more popular (and working) library

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var process = require('process');
-var exif = require('exif-component');
+var EXIF = require('exif-js');
 var toArray = require('data-uri-to-u8');
 var rotate = require('rotate-component');
 var resize = require('./lib/resize');
@@ -19,12 +19,13 @@ function fixOrientation (url, opts, fn) {
 
   var buf = toArray(url);
   var tags = {};
-  try { tags = exif(buf.buffer) } catch (err) {}
+  
+  try { tags = EXIF.readFromBinaryFile(buf.buffer) } catch (err) {}
 
   var toRotate = tags.Orientation
-    && typeof tags.Orientation.value == 'number'
-    && (tags.Orientation.value == 6
-    || tags.Orientation.value == 8);
+    && typeof tags.Orientation == 'number'
+    && (tags.Orientation == 6
+    || tags.Orientation == 8);
 
   if (!toRotate) {
     process.nextTick(function () {
@@ -36,7 +37,7 @@ function fixOrientation (url, opts, fn) {
   var s = size[buf.type](buf);
   var max = Math.max(s.width, s.height);
   var half = max / 2;
-  var dir = { 6: 1, 8: -1 }[tags.Orientation.value];
+  var dir = { 6: 1, 8: -1 }[tags.Orientation];
 
   var canvas = document.createElement('canvas');
   var ctx = canvas.getContext('2d');

--- a/package.json
+++ b/package.json
@@ -12,17 +12,21 @@
     "start": "node example/server.js"
   },
   "dependencies": {
-    "png-size": "~0.1.0",
-    "jpeg-size": "0.0.1",
     "data-uri-to-u8": "~1.0.0",
-    "exif-component": "0.0.2",
+    "exif-js": "^2.3.0",
+    "jpeg-size": "0.0.1",
+    "png-size": "~0.1.0",
     "rotate-component": "~1.0.0"
   },
   "devDependencies": {
     "ecstatic": "~0.4.5"
   },
   "keywords": [
-    "orientation", "exif", "data-url", "canvas", "data-uri"
+    "orientation",
+    "exif",
+    "data-url",
+    "canvas",
+    "data-uri"
   ],
   "author": {
     "name": "Julian Gruber",


### PR DESCRIPTION
Just moving `"exif-component": "0.0.2"` to  `"exif-js": "^2.3.0"`
Newer exif-component versions use textual orientation values and the old version of exif component has issue with various array buffers I have tried. This fixes it and also exif-js is much more popular and more up to date.